### PR TITLE
feat: Add gemini-2.5-pro-preview-05-06 to available models

### DIFF
--- a/app/pages/api-settings.tsx
+++ b/app/pages/api-settings.tsx
@@ -269,6 +269,7 @@ const ApiSettings = () => {
 
   const availableGeminiModels = [
     'gemini-2.5-pro-exp-03-25',
+    'gemini-2.5-pro-preview-05-06',
     'gemini-2.5-flash-preview-04-17', // 新增
     'gemini-2.0-flash-exp',
     'gemini-2.0-pro-exp-02-05',


### PR DESCRIPTION
This change adds the 'gemini-2.5-pro-preview-05-06' model to the list of available Gemini models in the API settings page. You can now select this model for your primary or backup Gemini configuration.